### PR TITLE
scripts: Make sure all scripts run with bash

### DIFF
--- a/build_and_install_bpfkv.sh
+++ b/build_and_install_bpfkv.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$(uname -r)" !=  "5.12.0-xrp+" ]; then
     printf "Not in XRP kernel. Please run the following commands to boot into XRP kernel:\n"
     printf "    sudo grub-reboot \"Advanced options for Ubuntu>Ubuntu, with Linux 5.12.0-xrp+\"\n"

--- a/build_and_install_kernel.sh
+++ b/build_and_install_kernel.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eux -o pipefail
+
 # Enable source
 printf "Installing dependencies...\n"
 sudo cp /etc/apt/sources.list /etc/apt/sources.list~
@@ -26,12 +29,12 @@ if [ ! -e "Makefile" ]; then
 fi
 
 # Cleanup the previous build
-rm ../linux-* 2> /dev/null
+rm -f ../linux-* 2> /dev/null
 make distclean
 
 # Configure kernel
 printf "Configuring kernel...\n"
-yes "" | make localmodconfig
+(yes "" || true) | make localmodconfig
 ./scripts/config -e CONFIG_DEBUG_INFO
 ./scripts/config -e CONFIG_BPF_SYSCALL
 ./scripts/config -e CONFIG_DEBUG_INFO_BTF

--- a/build_and_install_wiredtiger.sh
+++ b/build_and_install_wiredtiger.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$(uname -r)" !=  "5.12.0-xrp+" ]; then
     printf "Not in XRP kernel. Please run the following commands to boot into XRP kernel:\n"
     printf "    sudo grub-reboot \"Advanced options for Ubuntu>Ubuntu, with Linux 5.12.0-xrp+\"\n"

--- a/build_and_install_ycsb.sh
+++ b/build_and_install_ycsb.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Install build dependencies
 printf "Installing dependencies...\n"
 sudo apt-get update


### PR DESCRIPTION
In addition, make the build and install kernel script safer by adding
the following bash flags:
- -e: Abort on error.
- -u: Abort on unset variable.
- -x: Log command before executing.
- -o pipefail: Fail the whole pipeline immediately if one command fails.

We don't enable these flags for the other scripts yet as they may depend
on some erroneous behavior. For example, we had to change `yes ""` to
`(yes "" || true)` in the kernel build script.
